### PR TITLE
When the enum is `public`, the generated code is also `public`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,79 @@ enum Nightshade {
 }
 ```
 
+generates to 
+
+```swift
+enum Nightshade {
+  case potato(PotatoVariety), tomato(TomatoVariety)
+  case chili(ChiliVariety)
+
+  enum PotatoVariety: CaseIterable {
+    case russet, yukonGold, kennebec
+  }
+  
+  enum TomatoVariety: CaseIterable {
+    case roma, heirloom, cherry
+  }
+  
+  enum ChiliVariety: CaseIterable {
+    case jalapeño, arbol, habenero
+  }
+  
+  var id: ID {
+    switch self {
+    case .jalapeño: .jalapeño
+    case .arbol: .arbol
+    case .habenero: .habenero
+    }
+  }
+  
+  enum ID: String, Hashable, CaseIterable {
+    case potato, tomato, jalapeño
+  }
+}
+```
+
 then in code we can directly refer to the ID of the case.
 
 ```swift
 let romaTomato = Nightshade.tomato(.roma)
 XCTAssertEquals(romaTomato.id, .tomato)
+```
+
+## Public visibility
+
+If the enum is `public`, the generated `ID` enum and the
+generated `id` accessor will also be `public`. For example,
+
+```swift
+import IdentifiedEnumCases
+
+@IdentifiedEnumCases
+public enum AppRoute {
+  case item(ItemRoute)
+  case user(UserRoute)
+}
+```
+
+generates to
+
+```swift
+public enum AppRoute {
+  case item(ItemRoute)
+  case user(UserRoute)
+
+  public var id: ID {
+    switch self {
+    case .item: .item
+    case .user: .user
+  }
+
+  public enum ID: String, Hashable, CaseIterable {
+    case item
+    case user
+  }
+}
 ```
 
 ## Installation
@@ -42,7 +110,7 @@ In `Package.swift`, add the package to your dependencies.
 
 And add `"IdentifiedEnumCases"` to the list of your target's dependencies.
 
-You may need to trust and enable macro in Xcode.
+When prompted by Xcode, trust the macro.
 
 
 ## Swift macros?

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ enum Nightshade {
 }
 ```
 
-generates to 
+then in code we can directly refer to the ID of the case.
+
+```swift
+let romaTomato = Nightshade.tomato(.roma)
+XCTAssertEquals(romaTomato.id, .tomato)
+```
+
+because the macro generates to 
 
 ```swift
 enum Nightshade {
@@ -59,12 +66,7 @@ enum Nightshade {
 }
 ```
 
-then in code we can directly refer to the ID of the case.
-
-```swift
-let romaTomato = Nightshade.tomato(.roma)
-XCTAssertEquals(romaTomato.id, .tomato)
-```
+Very exciting!
 
 ## Public visibility
 

--- a/Sources/IdentifiedEnumCases/Library.swift
+++ b/Sources/IdentifiedEnumCases/Library.swift
@@ -8,5 +8,26 @@
 ///       case user(UserRoute)
 ///     }
 ///
+/// generates to
+///
+///     enum AppRoute {
+///       case item(ItemRoute)
+///       case user(UserRoute)
+///
+///       var id: ID {
+///         switch self {
+///         case .item: .item
+///         case .user: .user
+///       }
+///
+///       enum ID: String, Hashable, CaseIterable {
+///         case item
+///         case user
+///       }
+///     }
+///
+/// If the enum is `public`, the generated `ID` enum and the
+/// generated `id` accessor will also be `public`
+/// 
 @attached(member, names: named(ID), named(id))
 public macro IdentifiedEnumCases() -> () = #externalMacro(module: "IdentifiedEnumCasesMacro", type: "IdentifiedEnumCasesMacro")

--- a/Sources/IdentifiedEnumCasesMacro/IdentifiedEnumCasesMacro.swift
+++ b/Sources/IdentifiedEnumCasesMacro/IdentifiedEnumCasesMacro.swift
@@ -11,8 +11,6 @@ public struct IdentifiedEnumCasesMacro: MemberMacro {
     providingMembersOf declaration: Declaration,
     in context: Context) throws -> [SwiftSyntax.DeclSyntax] where Declaration : SwiftSyntax.DeclGroupSyntax, Context : SwiftSyntaxMacros.MacroExpansionContext {
       
-      
-      
       guard let declaration = declaration.as(EnumDeclSyntax.self) else {
         let enumError = Diagnostic(node: node._syntaxNode, message: Diagnostics.mustBeEnum)
         context.diagnose(enumError)
@@ -20,54 +18,14 @@ public struct IdentifiedEnumCasesMacro: MemberMacro {
       }
       
       
-      print("-------------------")
-      let keywords: [Keyword] = {
-        if let modifiers = declaration.modifiers {
-          return modifiers.children(viewMode: .fixedUp).flatMap { syntax in
-            return syntax.as(DeclModifierSyntax.self)?.children(viewMode: .fixedUp).compactMap({ syntax in
-              switch syntax.as(TokenSyntax.self)?.tokenKind {
-              case .keyword(.public):
-                return Keyword.public
-                
-              default:
-                return nil
-              }
-            }) ?? []
-          }
-        } else {
-          return []
-        }
-      }()
-      print("```````")
-      print(keywords)
-      print("```````")
-//      let keywords: [Keyword] = declaration.modifiers?.children(viewMode: .fixedUp).map({ syntax in
-//        syntax.as(DeclModifierSyntax.self)?.children(viewMode: .fixedUp).compactMmap({ syntax in
-//          switch syntax.as(TokenSyntax.self)?.tokenKind {
-//          case .keyword(.public):
-//            return Keyword.public
-//            
-//          default:
-//            return nil
-//          }
-//                 
-//        })
-//      })
-
-
-      print(declaration.identifier)
-
       guard let enumCases: [SyntaxProtocol] = declaration.memberBlock
-        .children(viewMode: .fixedUp)
-        .filter({ $0.kind == .memberDeclList })
+        .children(viewMode: .fixedUp).filter({ $0.kind == .memberDeclList })
         .first?
-        .children(viewMode: .fixedUp)
-        .filter({ $0.kind == SyntaxKind.memberDeclListItem })
+        .children(viewMode: .fixedUp).filter({ $0.kind == SyntaxKind.memberDeclListItem })
         .flatMap({ $0.children(viewMode: .fixedUp).filter({ $0.kind == .enumCaseDecl })})
         .flatMap({ $0.children(viewMode: .fixedUp).filter({ $0.kind == .enumCaseElementList })})
         .flatMap({ $0.children(viewMode: .fixedUp).filter({ $0.kind == .enumCaseElement })})
       else {
-        
         let enumError = Diagnostic(node: node._syntaxNode, message: Diagnostics.mustHaveCases)
         context.diagnose(enumError)
         return []
@@ -94,16 +52,7 @@ public struct IdentifiedEnumCasesMacro: MemberMacro {
       let enumID = "enum ID: String, Equatable, CaseIterable {\n\(caseIds.map { "  case \($0)\n" }.joined())}"
       let idAccessor = "var id: ID {\n  switch self {\n\(caseIds.map { "  case .\($0): .\($0)\n" }.joined())  }\n}"
       
-      
-      let isPublic = if let modifiers = declaration.modifiers, !modifiers.children(viewMode: .fixedUp).filter({ syntax in
-        syntax.tokens(viewMode: .fixedUp).contains(TokenSyntax.keyword(.public)) }).isEmpty {
-        true
-      } else {
-        false
-      }
-      
-      
-      return if isPublic {
+      return if declaration.isPublic {
         [
           DeclSyntax(stringLiteral: "public \(enumID)"),
           DeclSyntax(stringLiteral: "public \(idAccessor)")
@@ -134,6 +83,29 @@ public struct IdentifiedEnumCasesMacro: MemberMacro {
     }
     
     public var severity: DiagnosticSeverity { .error }
+  }
+}
+
+private extension DeclGroupSyntax {
+  var isPublic: Bool {
+    let keywords: [Keyword] = {
+      if let modifiers = self.modifiers {
+        return modifiers.children(viewMode: .fixedUp).flatMap { syntax in
+          return syntax.as(DeclModifierSyntax.self)?.children(viewMode: .fixedUp).compactMap({ syntax in
+            switch syntax.as(TokenSyntax.self)?.tokenKind {
+            case .keyword(.public):
+              return Keyword.public
+            default:
+              return nil
+            }
+          }) ?? []
+        }
+      } else {
+        return []
+      }
+    }()
+    
+    return keywords.contains(Keyword.public)
   }
 }
 

--- a/Sources/IdentifiedEnumCasesMacro/IdentifiedEnumCasesMacro.swift
+++ b/Sources/IdentifiedEnumCasesMacro/IdentifiedEnumCasesMacro.swift
@@ -17,7 +17,6 @@ public struct IdentifiedEnumCasesMacro: MemberMacro {
         return []
       }
       
-      
       guard let enumCases: [SyntaxProtocol] = declaration.memberBlock
         .children(viewMode: .fixedUp).filter({ $0.kind == .memberDeclList })
         .first?
@@ -49,10 +48,10 @@ public struct IdentifiedEnumCasesMacro: MemberMacro {
         return []
       }
       
-      let enumID = "enum ID: String, Equatable, CaseIterable {\n\(caseIds.map { "  case \($0)\n" }.joined())}"
+      let enumID = "enum ID: String, Hashable, CaseIterable {\n\(caseIds.map { "  case \($0)\n" }.joined())}"
       let idAccessor = "var id: ID {\n  switch self {\n\(caseIds.map { "  case .\($0): .\($0)\n" }.joined())  }\n}"
       
-      return if declaration.isPublic {
+      return if declaration.hasPublicModifier {
         [
           DeclSyntax(stringLiteral: "public \(enumID)"),
           DeclSyntax(stringLiteral: "public \(idAccessor)")
@@ -87,7 +86,7 @@ public struct IdentifiedEnumCasesMacro: MemberMacro {
 }
 
 private extension DeclGroupSyntax {
-  var isPublic: Bool {
+  var hasPublicModifier: Bool {
     let keywords: [Keyword] = {
       if let modifiers = self.modifiers {
         return modifiers.children(viewMode: .fixedUp).flatMap { syntax in

--- a/Tests/MacroTests/MacroTests.swift
+++ b/Tests/MacroTests/MacroTests.swift
@@ -36,7 +36,7 @@ final class MacroTests: XCTestCase {
               }
               enum EggplantVariety {
               }
-              enum ID: String, Equatable, CaseIterable {
+              enum ID: String, Hashable, CaseIterable {
                 case potato
                 case tomato
                 case eggplant
@@ -83,7 +83,7 @@ final class MacroTests: XCTestCase {
             }
             public enum EggplantVariety {
             }
-            public enum ID: String, Equatable, CaseIterable {
+            public enum ID: String, Hashable, CaseIterable {
               case potato
               case tomato
               case eggplant

--- a/Tests/MacroTests/MacroTests.swift
+++ b/Tests/MacroTests/MacroTests.swift
@@ -56,6 +56,53 @@ final class MacroTests: XCTestCase {
             macros: testMacros
     )
   }
+  
+  func testPublicMacro() {
+    assertMacroExpansion(
+          """
+          @IdentifiedEnumCases
+          public enum Nightshade {
+            case potato(PotatoVariety), tomato(TomatoVariety)
+            case eggplant(EggplantVariety)
+          
+            public enum PotatoVariety {}
+            public enum TomatoVariety {}
+            public enum EggplantVariety {}
+          }
+          """,
+          expandedSource:
+          """
+          
+          public enum Nightshade {
+            case potato(PotatoVariety), tomato(TomatoVariety)
+            case eggplant(EggplantVariety)
+          
+            public enum PotatoVariety {
+            }
+            public enum TomatoVariety {
+            }
+            public enum EggplantVariety {
+            }
+            public enum ID: String, Equatable, CaseIterable {
+              case potato
+              case tomato
+              case eggplant
+            }
+            public var id: ID {
+              switch self {
+              case .potato:
+                .potato
+              case .tomato:
+                .tomato
+              case .eggplant:
+                .eggplant
+              }
+            }
+          }
+          """,
+          macros: testMacros
+    )
+  }
     
   func testMustBeEnumDiagnostic() {
     assertMacroExpansion("@IdentifiedEnumCases struct Tomato {}",


### PR DESCRIPTION
Also, the generated enum conforms to `Hashable` which implies `Equatable`, instead of simply `Equatable`