### PR TITLE
Rename to `CaseID`

### DIFF
--- a/Sources/IdentifiedEnumCases/Library.swift
+++ b/Sources/IdentifiedEnumCases/Library.swift
@@ -29,5 +29,5 @@
 /// If the enum is `public`, the generated `ID` enum and the
 /// generated `id` accessor will also be `public`
 /// 
-@attached(member, names: named(ID), named(id))
+@attached(member, names: named(CaseID), named(caseID))
 public macro IdentifiedEnumCases() -> () = #externalMacro(module: "IdentifiedEnumCasesMacro", type: "IdentifiedEnumCasesMacro")

--- a/Sources/IdentifiedEnumCasesMacro/IdentifiedEnumCasesMacro.swift
+++ b/Sources/IdentifiedEnumCasesMacro/IdentifiedEnumCasesMacro.swift
@@ -47,21 +47,15 @@ public struct IdentifiedEnumCasesMacro: MemberMacro {
         context.diagnose(enumError)
         return []
       }
-      
-      let enumID = "enum ID: String, Hashable, CaseIterable {\n\(caseIds.map { "  case \($0)\n" }.joined())}"
-      let idAccessor = "var id: ID {\n  switch self {\n\(caseIds.map { "  case .\($0): .\($0)\n" }.joined())  }\n}"
-      
-      return if declaration.hasPublicModifier {
-        [
-          DeclSyntax(stringLiteral: "public \(enumID)"),
-          DeclSyntax(stringLiteral: "public \(idAccessor)")
-        ]
-      } else {
-        [
-          DeclSyntax(stringLiteral: enumID),
-          DeclSyntax(stringLiteral: idAccessor)
-        ]
-      }
+
+      let modifier = declaration.hasPublicModifier ? "public " : ""
+      let enumID = "\(modifier)enum CaseID: String, Hashable, CaseIterable, CustomStringConvertible {\n\(caseIds.map { "  case \($0)\n" }.joined())\n  \(modifier)var description: String {\nself.rawValue\n  }\n}"
+      let idAccessor = "\(modifier)var caseID: CaseID {\n  switch self {\n\(caseIds.map { "  case .\($0): .\($0)\n" }.joined())  }\n}"
+
+      return [
+        DeclSyntax(stringLiteral: enumID),
+        DeclSyntax(stringLiteral: idAccessor)
+      ]
     }
   
   public enum Diagnostics: String, DiagnosticMessage {

--- a/Sources/NightshadesExample/main.swift
+++ b/Sources/NightshadesExample/main.swift
@@ -17,5 +17,5 @@ enum Nightshade {
 }
 
 let romaTomato = Nightshade.tomato(.roma)
-print("ID equality:", romaTomato.id == Nightshade.ID.tomato)
+print("ID equality:", romaTomato.caseID == Nightshade.CaseID.tomato)
 

--- a/Sources/URLsExample/AppRoute.url.swift
+++ b/Sources/URLsExample/AppRoute.url.swift
@@ -9,9 +9,9 @@ extension AppRoute {
   var urlComponents: [String] {
     switch self {
     case .item(let itemRoute):
-      [self.id.rawValue] + itemRoute.urlComponents
+      [self.caseID.rawValue] + itemRoute.urlComponents
     case .home, .about, .shop:
-      [self.id.rawValue]
+      [self.caseID.rawValue]
     }
   }
 }
@@ -23,14 +23,14 @@ extension ItemRoute {
     case .filter(let filter):
       switch filter {
       case .all:
-        [self.id.rawValue, filter.id.rawValue]
+        [self.caseID.rawValue, filter.caseID.rawValue]
       case .substring(let string):
-        [self.id.rawValue, filter.id.rawValue, string.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!]
+        [self.caseID.rawValue, filter.caseID.rawValue, string.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!]
       }
     case .new:
-      [self.id.rawValue]
+      [self.caseID.rawValue]
     case .view(let itemId):
-      [self.id.rawValue, itemId.id.uuidString]
+      [self.caseID.rawValue, itemId.id.uuidString]
     }
   }
 }

--- a/Tests/MacroTests/MacroTests.swift
+++ b/Tests/MacroTests/MacroTests.swift
@@ -36,12 +36,16 @@ final class MacroTests: XCTestCase {
               }
               enum EggplantVariety {
               }
-              enum ID: String, Hashable, CaseIterable {
+              enum CaseID: String, Hashable, CaseIterable, CustomStringConvertible {
                 case potato
                 case tomato
                 case eggplant
+
+                var description: String {
+                  self.rawValue
+                }
               }
-              var id: ID {
+              var caseID: CaseID {
                 switch self {
                 case .potato:
                   .potato
@@ -83,12 +87,16 @@ final class MacroTests: XCTestCase {
             }
             public enum EggplantVariety {
             }
-            public enum ID: String, Hashable, CaseIterable {
+            public enum CaseID: String, Hashable, CaseIterable, CustomStringConvertible {
               case potato
               case tomato
               case eggplant
+
+              public var description: String {
+                self.rawValue
+              }
             }
-            public var id: ID {
+            public var caseID: CaseID {
               switch self {
               case .potato:
                 .potato


### PR DESCRIPTION
1. Better matches the style of `CaseIterable`
2. `CaseID` is less likely to collide than `ID`

Thanks for the feedback!