### PR TITLE
Fix: Only a freestanding expression macro can produce a result of type '()' in Xcode 15 Beta 7

### DIFF
--- a/Sources/IdentifiedEnumCases/Library.swift
+++ b/Sources/IdentifiedEnumCases/Library.swift
@@ -30,4 +30,4 @@
 /// generated `id` accessor will also be `public`
 /// 
 @attached(member, names: named(CaseID), named(caseID))
-public macro IdentifiedEnumCases() -> () = #externalMacro(module: "IdentifiedEnumCasesMacro", type: "IdentifiedEnumCasesMacro")
+public macro IdentifiedEnumCases() = #externalMacro(module: "IdentifiedEnumCasesMacro", type: "IdentifiedEnumCasesMacro")


### PR DESCRIPTION
Uses "Remove the result type if the macro does not produce a value" fix-it